### PR TITLE
Починил багу со срабатыванием автоподстановки

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "wirenboard",
   "displayName": "MDX WB Editor Tolls",
   "description": "Preview MDX files with Wiren Board components, as well as syntax backlight, snippet and auto filling.",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/providers/wbCompletionProvider.ts
+++ b/src/providers/wbCompletionProvider.ts
@@ -9,7 +9,7 @@ export class WBCompletionProvider implements vscode.CompletionItemProvider {
 
         const text = document.lineAt(position).text.slice(0, position.character);
         // триггер — ввод двоеточия и начало имени компонента
-        const m = text.match(/:([a-z0-9-]*)$/i);
+        const m = text.match(/^\s*:([a-z0-9-]*)$/i);
         if (!m) return undefined;
         const prefixTyped = m[1]; // то, что после двоеточия
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Автоподстановка компонента срабатывала в любом месте документа, а надо только в начале строки.

___________________________________
**Что поменялось для пользователей:**
Их теперь не бесит автодополнение ни к месту.

___________________________________
**Как проверял/а:**
Поставил в vscode и проверил, ложных срабатываний нет.

