### PR TITLE
Починил парсинг фронтматтера

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "wirenboard",
   "displayName": "MDX WB Editor Tolls",
   "description": "Preview MDX files with Wiren Board components, as well as syntax backlight, snippet and auto filling.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 export class MarkdownParser {
   parseFrontmatter(text: string): { content: string; attributes: Record<string, string> } | null {
-    const frontmatterMatch = text.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+    const frontmatterMatch = text.match(/^---\s*\n([\s\S]*?)\n---(\s*\n)?/);
     if (!frontmatterMatch) return null;
 
     const attributes: Record<string, string> = {};


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Если после фронтматтера не было пустой строки, то в рендере появлялся его исходный код.

___________________________________
**Что поменялось для пользователей:**
Корректно отображаются md-файлы без контента и пустой строки после фронтматтера.

___________________________________
**Как проверял/а:**
Запустил, посмотрел на файлике.

